### PR TITLE
リファクタリング・バグ修正

### DIFF
--- a/laravel-practis/app/Http/Controllers/CsvExportHistoryController.php
+++ b/laravel-practis/app/Http/Controllers/CsvExportHistoryController.php
@@ -14,35 +14,31 @@ class CsvExportHistoryController extends Controller
 {
     public function index(): View
     {
-        $csv_export_histories = CsvExportHistory::orderBy('created_at', 'desc')->paginate();
+        $csv_export_histories = CsvExportHistory::with('download_user')->orderBy('created_at', 'desc')->paginate();
         return view('csv_export_histories.index', compact('csv_export_histories'));
     }
 
     public function store(Request $request): StreamedResponse
     {
+        $searchType = $request->search_type;
+        $searchKeyword = $request->search_keyword;
         if (Auth::user()->isAdmin()) {
-            $searchType = $request->search_type;
-            $searchKeyword = $request->search_keyword;
-
             if ($searchType === 'user') {
-                $users = User::searchUser($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
             } elseif ($searchType === 'company') {
-                $users = User::searchCompany($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchCompany($searchKeyword)->paginate()->withQueryString();
             } elseif ($searchType === 'section') {
-                $users = User::searchSection($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
             } else {
-                $users = User::paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->paginate()->withQueryString();
             }
         } else {
-            $searchType = $request->search_type;
-            $searchKeyword = $request->search_keyword;
-
             if ($searchType === 'user') {
-                $users = User::searchUser($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
             } elseif ($searchType === 'section') {
-                $users = User::query()->searchSection($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
             } else {
-                $users = Auth::user()->company->users()->paginate()->withQueryString();
+                $users = Auth::user()->company->users()->with(['company', 'sections'])->paginate()->withQueryString();
             }
         }
 

--- a/laravel-practis/app/Http/Controllers/CsvExportHistoryController.php
+++ b/laravel-practis/app/Http/Controllers/CsvExportHistoryController.php
@@ -22,25 +22,8 @@ class CsvExportHistoryController extends Controller
     {
         $searchType = $request->search_type;
         $searchKeyword = $request->search_keyword;
-        if (Auth::user()->isAdmin()) {
-            if ($searchType === 'user') {
-                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
-            } elseif ($searchType === 'company') {
-                $users = User::with(['company', 'sections'])->searchCompany($searchKeyword)->paginate()->withQueryString();
-            } elseif ($searchType === 'section') {
-                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
-            } else {
-                $users = User::with(['company', 'sections'])->paginate()->withQueryString();
-            }
-        } else {
-            if ($searchType === 'user') {
-                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
-            } elseif ($searchType === 'section') {
-                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
-            } else {
-                $users = Auth::user()->company->users()->with(['company', 'sections'])->paginate()->withQueryString();
-            }
-        }
+        $user = New User();
+        $users = $user->keywordSearch($searchType, $searchKeyword);
 
         $file_name = sprintf('users-%s.csv', now()->format('YmdHis'));
         $stream = $this->createCsv($users);

--- a/laravel-practis/app/Http/Controllers/UserController.php
+++ b/laravel-practis/app/Http/Controllers/UserController.php
@@ -17,29 +17,25 @@ class UserController extends Controller
 
     public function index(Request $request): View
     {
+        $searchType = $request->search_type;
+        $searchKeyword = $request->search_keyword;
         if (Auth::user()->isAdmin()) {
-            $searchType = $request->search_type;
-            $searchKeyword = $request->search_keyword;
-
             if ($searchType === 'user') {
-                $users = User::searchUser($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
             } elseif ($searchType === 'company') {
-                $users = User::searchCompany($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchCompany($searchKeyword)->paginate()->withQueryString();
             } elseif ($searchType === 'section') {
-                $users = User::searchSection($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
             } else {
-                $users = User::paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->paginate()->withQueryString();
             }
         } else {
-            $searchType = $request->search_type;
-            $searchKeyword = $request->search_keyword;
-
             if ($searchType === 'user') {
-                $users = User::searchUser($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
             } elseif ($searchType === 'section') {
-                $users = User::query()->searchSection($searchKeyword)->paginate()->withQueryString();
+                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
             } else {
-                $users = Auth::user()->company->users()->paginate()->withQueryString();
+                $users = Auth::user()->company->users()->with(['company', 'sections'])->paginate()->withQueryString();
             }
         }
 

--- a/laravel-practis/app/Http/Controllers/UserController.php
+++ b/laravel-practis/app/Http/Controllers/UserController.php
@@ -19,25 +19,8 @@ class UserController extends Controller
     {
         $searchType = $request->search_type;
         $searchKeyword = $request->search_keyword;
-        if (Auth::user()->isAdmin()) {
-            if ($searchType === 'user') {
-                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
-            } elseif ($searchType === 'company') {
-                $users = User::with(['company', 'sections'])->searchCompany($searchKeyword)->paginate()->withQueryString();
-            } elseif ($searchType === 'section') {
-                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
-            } else {
-                $users = User::with(['company', 'sections'])->paginate()->withQueryString();
-            }
-        } else {
-            if ($searchType === 'user') {
-                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
-            } elseif ($searchType === 'section') {
-                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
-            } else {
-                $users = Auth::user()->company->users()->with(['company', 'sections'])->paginate()->withQueryString();
-            }
-        }
+        $user = New User();
+        $users = $user->keywordSearch($searchType, $searchKeyword);
 
         return view('users.index', compact('users'));
     }

--- a/laravel-practis/app/Models/User.php
+++ b/laravel-practis/app/Models/User.php
@@ -106,6 +106,31 @@ class User extends Authenticatable
         return $this->role === 'admin';
     }
 
+    public function keywordSearch($searchType, $searchKeyword)
+    {
+        if (Auth::user()->isAdmin()) {
+            if ($searchType === 'user') {
+                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
+            } elseif ($searchType === 'company') {
+                $users = User::with(['company', 'sections'])->searchCompany($searchKeyword)->paginate()->withQueryString();
+            } elseif ($searchType === 'section') {
+                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
+            } else {
+                $users = User::with(['company', 'sections'])->paginate()->withQueryString();
+            }
+        } else {
+            if ($searchType === 'user') {
+                $users = User::with(['company', 'sections'])->searchUser($searchKeyword)->paginate()->withQueryString();
+            } elseif ($searchType === 'section') {
+                $users = User::with(['company', 'sections'])->searchSection($searchKeyword)->paginate()->withQueryString();
+            } else {
+                $users = Auth::user()->company->users()->with(['company', 'sections'])->paginate()->withQueryString();
+            }
+        }
+
+        return $users;
+    }
+
     public function scopeSearchUser($query, $user_name)
     {
         if (!is_null($user_name)) {

--- a/laravel-practis/app/Models/User.php
+++ b/laravel-practis/app/Models/User.php
@@ -118,14 +118,14 @@ class User extends Authenticatable
             // 単語をループで回す
             if (Auth::user()->isAdmin()) {
                 foreach ($keywords as $word) {
-                    $query->where('users.name', 'like', '%' . $word . '%');
+                    $query->orWhere('users.name', 'like', '%' . $word . '%');
                 }
             } else {
                 $company_id = Auth::user()->company_id;
 
                 $query->where('company_id', $company_id)->where(function ($query) use ($keywords) {
                     foreach ($keywords as $word) {
-                        $query->where('users.name', 'like', '%' . $word . '%');
+                        $query->orWhere('users.name', 'like', '%' . $word . '%');
                     }
                 });
             }

--- a/laravel-practis/app/Models/User.php
+++ b/laravel-practis/app/Models/User.php
@@ -147,7 +147,7 @@ class User extends Authenticatable
             // 単語をループで回す
             if (Auth::user()->isAdmin()) {
                 foreach ($keywords as $word) {
-                    $query->whereHas('company', function ($query) use ($word) {
+                    $query->orWhereHas('company', function ($query) use ($word) {
                         $query->where('name', 'like', '%' . $word . '%');
                     });
                 }

--- a/laravel-practis/app/Models/User.php
+++ b/laravel-practis/app/Models/User.php
@@ -170,7 +170,7 @@ class User extends Authenticatable
             // 単語をループで回す
             if (Auth::user()->isAdmin()) {
                 foreach ($keywords as $word) {
-                    $query->whereHas('sections', function ($query) use ($word) {
+                    $query->orWhereHas('sections', function ($query) use ($word) {
                         $query->where('name', 'like', '%' . $word . '%');
                     });
                 }
@@ -178,8 +178,13 @@ class User extends Authenticatable
                 $company_id = Auth::user()->company_id;
                 $query->where('company_id', $company_id)->where(function ($query) use ($keywords) {
                     $query->whereHas('sections', function ($query) use ($keywords) {
-                        foreach ($keywords as $word) {
-                            $query->Where('name', 'like', '%' . $word . '%');
+                        foreach ($keywords as $index => $word) {
+                            // 最初のキーワードに対してはwhereを使用し、それ以降のキーワードに対してはorWhereを使用
+                            if ($index === 0) {
+                                $query->where('name', 'like', '%' . $word . '%');
+                            } else {
+                                $query->orWhere('name', 'like', '%' . $word . '%');
+                            }
                         }
                     });
                 });

--- a/laravel-practis/composer.json
+++ b/laravel-practis/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.8",
         "barryvdh/laravel-ide-helper": "^2.13",
+        "beyondcode/laravel-query-detector": "^1.7",
         "fakerphp/faker": "^1.9.1",
         "laravel/breeze": "^1.19",
         "laravel/pint": "^1.0",

--- a/laravel-practis/composer.lock
+++ b/laravel-practis/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dae20ee56c218c8167e201ad5192a30",
+    "content-hash": "d32b929c2dcd96e65430aba118ff8c29",
     "packages": [
         {
             "name": "brick/math",
@@ -5711,6 +5711,66 @@
                 "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.1.0"
             },
             "time": "2022-10-31T15:35:43+00:00"
+        },
+        {
+            "name": "beyondcode/laravel-query-detector",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beyondcode/laravel-query-detector.git",
+                "reference": "40c7e168fcf7eeb80d8e96f7922e05ab194269c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beyondcode/laravel-query-detector/zipball/40c7e168fcf7eeb80d8e96f7922e05ab194269c8",
+                "reference": "40c7e168fcf7eeb80d8e96f7922e05ab194269c8",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "laravel/legacy-factories": "^1.0",
+                "orchestra/testbench": "^3.0 || ^4.0 || ^5.0 || ^6.0|^8.0",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "BeyondCode\\QueryDetector\\QueryDetectorServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BeyondCode\\QueryDetector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marcel Pociot",
+                    "email": "marcel@beyondco.de",
+                    "homepage": "https://beyondcode.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel N+1 Query Detector",
+            "homepage": "https://github.com/beyondcode/laravel-query-detector",
+            "keywords": [
+                "beyondcode",
+                "laravel-query-detector"
+            ],
+            "support": {
+                "issues": "https://github.com/beyondcode/laravel-query-detector/issues",
+                "source": "https://github.com/beyondcode/laravel-query-detector/tree/1.7.0"
+            },
+            "time": "2023-02-15T10:37:22+00:00"
         },
         {
             "name": "composer/class-map-generator",

--- a/laravel-practis/database/factories/CsvExportHistoryFactory.php
+++ b/laravel-practis/database/factories/CsvExportHistoryFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,6 +18,9 @@ class CsvExportHistoryFactory extends Factory
     public function definition(): array
     {
         return [
+            'download_user_id' => function () {
+                return User::query()->inRandomOrder()->first()->id;
+            },
             'file_name' => $this->faker->unique()->word . '.csv',
         ];
     }

--- a/laravel-practis/tests/Feature/Http/Controllers/CsvExportHistoryControllerTest.php
+++ b/laravel-practis/tests/Feature/Http/Controllers/CsvExportHistoryControllerTest.php
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class CsvExportHistoryController extends TestCase
+class CsvExportHistoryControllerTest extends TestCase
 {
     use RefreshDatabase;
     use WithFaker;
@@ -72,5 +72,10 @@ class CsvExportHistoryController extends TestCase
         $response = $this->actingAs($this->user)->get($url);
         $response->assertStatus(200);
         $response->assertDownload();
+
+        $this->csvExportHistory = CsvExportHistory::factory()->create();
+        $url = route('csv_export_histories.show', $this->csvExportHistory);
+        $response = $this->actingAs($this->user)->get($url);
+        $response->assertStatus(500);
     }
 }


### PR DESCRIPTION
## やったこと
- `laravel-query-detector`導入 N+1問題解決
- キーワードでユーザーを検索するメソッドを、モデルに切り分けて共通化
- ユーザー名、会社名、部署名、それぞれ複数ワードで検索可能に修正
  - 例）田中、山田で検索したときに、両方のユーザーがヒットする